### PR TITLE
Allow injection into all pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.youtube.com/*"
+        "<all_urls>"
       ],
       "js": [
         "src/inject/content_script.js"


### PR DESCRIPTION
This patch will allow for injecting the script into any page, dealing with cases where a YouTube video is embedded on a different website. It will also allow for other players that detect the support video formats to be blocked from choosing VPx/WebM, ensuring H.264 is served in all cases.