### PR TITLE
Add option to enable/disable the plugin.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,5 +23,7 @@
   ],
   "web_accessible_resources": [
     "src/inject/inject.js"
-  ]
+  ],
+  "options_page": "options.html",
+  "permissions": [ "storage" ]
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+<title>h264ify Options</title>
+</head>
+<body>
+<label><input type="checkbox" id="enable">Enable h264ify</label>
+<button id="save">Save</button>
+
+<script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,21 @@
+// Saves options to chrome.storage
+function save_options() {
+  var enable = document.getElementById('enable').checked;
+  chrome.storage.local.set({
+    enable: enable
+  });
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  // Use default value color = 'red' and likesColor = true.
+  chrome.storage.local.get({
+    enable: true
+  }, function(items) {
+    document.getElementById('enable').checked = items.enable;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);

--- a/src/inject/content_script.js
+++ b/src/inject/content_script.js
@@ -22,10 +22,17 @@
  * SOFTWARE.
  */
 
-var injectScript = document.createElement('script');
-injectScript.src = chrome.extension.getURL('src/inject/inject.js');
-injectScript.onload = function() {
-  this.parentNode.removeChild(this);
-};
-(document.head || document.documentElement).appendChild(injectScript);
+chrome.storage.local.get({
+  enable: true
+}, function(items) {
+  if (!items.enable) {
+    return;
+  }
 
+  var injectScript = document.createElement('script');
+  injectScript.src = chrome.extension.getURL('src/inject/inject.js');
+  injectScript.onload = function() {
+    this.parentNode.removeChild(this);
+  };
+  (document.head || document.documentElement).appendChild(injectScript);
+});


### PR DESCRIPTION
Adding a very simple options page for enable and disable the plugin.

It might be useful when the extension is synced across different computers but only want some of them having VP9 disabled.