### PR TITLE
Add option to enable h264ify only when on battery

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "h264ify",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "manifest_version": 2,
   "description": "Makes YouTube stream H.264 videos instead of VP8/VP9 videos",
   "homepage_url": "https://github.com/erkserkserks/h264ify",

--- a/options.html
+++ b/options.html
@@ -4,8 +4,9 @@
 <head><title>h264ify Options</title></head>
 <body>
 <h1>h264ify Options</h1>
-<label><input type="checkbox" id="enable" class="checkbox">Enable h264ify</label>
-<label><input type="checkbox" id="block_60fps" class="checkbox">Block 60fps video</label>
+<label><input type="checkbox" id="enable" class="checkbox">Enable h264ify</label><br>
+<label><input type="checkbox" id="block_60fps" class="checkbox">Block 60fps video</label><br>
+<label><input type="checkbox" id="battery_only" class="checkbox">Enable on battery only</label><br>
 <script src="options.js"></script>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -2,9 +2,11 @@
 function save_options() {
   var enable = document.getElementById('enable').checked;
   var block_60fps = document.getElementById('block_60fps').checked;
+  var battery_only = document.getElementById('battery_only').checked;
   chrome.storage.local.set({
     enable: enable,
-    block_60fps: block_60fps
+    block_60fps: block_60fps,
+    battery_only: battery_only,
   });
 }
 
@@ -13,10 +15,12 @@ function restore_options() {
   // Use default value enable = true and block_60fps = false
   chrome.storage.local.get({
     enable: true,
-    block_60fps: false
+    block_60fps: false,
+    battery_only: false,
   }, function(options) {
     document.getElementById('enable').checked = options.enable;
     document.getElementById('block_60fps').checked = options.block_60fps;
+    document.getElementById('battery_only').checked = options.battery_only;
   });
 }
 

--- a/src/inject/content_script.js
+++ b/src/inject/content_script.js
@@ -33,6 +33,9 @@ if (localStorage['h264ify-enable'] === undefined) {
 if (localStorage['h264ify-block_60fps'] === undefined) {
   localStorage['h264ify-block_60fps'] = false;
 }
+if (localStorage['h264ify-battery_only'] === undefined) {
+  localStorage['h264ify-battery_only'] = false;
+}
 
 // Cache chrome.storage.local options in localStorage.
 // This is needed because chrome.storage.local.get() is async and we want to
@@ -41,10 +44,12 @@ if (localStorage['h264ify-block_60fps'] === undefined) {
 chrome.storage.local.get({
   // Set defaults
   enable: true,
-  block_60fps: false
+  block_60fps: false,
+  battery_only: false,
  }, function(options) {
    localStorage['h264ify-enable'] = options.enable;
    localStorage['h264ify-block_60fps'] = options.block_60fps;
+   localStorage['h264ify-battery_only'] = options.battery_only;
  }
 );
 

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -48,16 +48,28 @@ function inject () {
     };
   }
 
-  // Override video element canPlayType() function
-  var videoElem = document.createElement('video');
-  var origCanPlayType = videoElem.canPlayType.bind(videoElem);
-  videoElem.__proto__.canPlayType = makeModifiedTypeChecker(origCanPlayType);
+  function override() {
+    // Override video element canPlayType() function
+    var videoElem = document.createElement('video');
+    var origCanPlayType = videoElem.canPlayType.bind(videoElem);
+    videoElem.__proto__.canPlayType = makeModifiedTypeChecker(origCanPlayType);
 
-  // Override media source extension isTypeSupported() function
-  var mse = window.MediaSource;
-  // Check for MSE support before use
-  if (mse === undefined) return;
-  var origIsTypeSupported = mse.isTypeSupported.bind(mse);
-  mse.isTypeSupported = makeModifiedTypeChecker(origIsTypeSupported);
+    // Override media source extension isTypeSupported() function
+    var mse = window.MediaSource;
+    // Check for MSE support before use
+    if (mse === undefined) return;
+    var origIsTypeSupported = mse.isTypeSupported.bind(mse);
+    mse.isTypeSupported = makeModifiedTypeChecker(origIsTypeSupported);
+  }
+
+  if (localStorage['h264ify-battery_only'] && navigator.getBattery) {
+    navigator.getBattery().then(function(battery) {
+      if (!battery.charging) {
+        override();
+      }
+    })
+  } else {
+    override();
+  }
 }
 


### PR DESCRIPTION
Add option to enable h264ify and block 60fps video only when computer is on battery.