### PR TITLE
Fix h264ify thinking battery-only mode is always enabled

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -27,7 +27,7 @@ function inject () {
     return;
   }
 
-  if (localStorage['h264ify-battery_only'] == 'true' && navigator.getBattery) {
+  if (localStorage['h264ify-battery_only'] === 'true' && navigator.getBattery) {
     navigator.getBattery().then(function(battery) {
       if (!battery.charging) {
         override();

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -27,7 +27,7 @@ function inject () {
     return;
   }
 
-  if (localStorage['h264ify-battery_only'] && navigator.getBattery) {
+  if (localStorage['h264ify-battery_only'] == 'true' && navigator.getBattery) {
     navigator.getBattery().then(function(battery) {
       if (!battery.charging) {
         override();


### PR DESCRIPTION
h264ify looks for a boolean in localStorage when it is always either a string or `undefined`. `"false"` doesn't coerce to false, so it will act as if battery-only mode is always on.