### PR TITLE
Add Google Meet as a website this extensions works on

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,9 @@
       "matches": [
         "*://*.youtube.com/*",
         "*://*.youtube-nocookie.com/*",
-        "*://*.youtu.be/*"
+        "*://*.youtu.be/*",
+        "*://*.html5test.com/*",
+        "*://meet.google.com/*"
       ],
       "js": [
         "src/inject/inject.js",


### PR DESCRIPTION
Google Meet has been a huge laptop battery drain for me due to the VP9 codecs, so I thought this could change things for the better. And it did. It's a much better experience for machines without hardware VP9 decoders like Macbooks.

@erkserkserks please consider merging and publishing this to the store.

Added:
- HTML5 test to see if this changes anything (it does)
- Google Meet to try and save battery