### PR TITLE
remove reference to youtube.com/html5

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,3 @@ Looking for the Firefox version? See: https://github.com/erkserkserks/h264ify-fi
 Install from here: https://chrome.google.com/webstore/detail/h264ify/aleakchihdccplidncghkekgioiakgal
 
 Note: [You may need to enable GPU acceleration as well] (http://www.webupd8.org/2014/01/enable-hardware-acceleration-in-chrome.html)
-
-If all goes well, when you visit https://www.youtube.com/html5, you should see this:
-![](https://github.com/erkserkserks/h264ify/blob/master/noncode/html5_video_support.png)
-
-


### PR DESCRIPTION
the youtube.com/html5 website doesn't work anymore

![YouTube HTML5 Testing Page not working anymore](https://github.com/user-attachments/assets/71178692-0d9e-4c4c-b1ae-fe664a99bf74)
